### PR TITLE
Add `terraform fmt -check` GitHub Actions workflow

### DIFF
--- a/.github/workflows/terraform-fmt.yml
+++ b/.github/workflows/terraform-fmt.yml
@@ -1,0 +1,23 @@
+name: terraform-fmt
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  fmt:
+    name: terraform fmt -check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.9.8
+          terraform_wrapper: false
+
+      - name: Terraform fmt check
+        run: terraform fmt -check -recursive

--- a/terraform/0-structure/remote-state.tf
+++ b/terraform/0-structure/remote-state.tf
@@ -6,20 +6,20 @@
 
 
 resource "random_id" "storage_account" {
-      byte_length = 8
+  byte_length = 8
 }
 
 
 resource "azurerm_storage_account" "tfstate" {
-    name = "tfstate${lower(random_id.storage_account.hex)}"
-    location = var.location
-    resource_group_name = var.rg_tfstate
-    account_tier = "Standard"
-    account_replication_type = var.tfstate_account_replication_type
-    is_hns_enabled = true
+  name                     = "tfstate${lower(random_id.storage_account.hex)}"
+  location                 = var.location
+  resource_group_name      = var.rg_tfstate
+  account_tier             = "Standard"
+  account_replication_type = var.tfstate_account_replication_type
+  is_hns_enabled           = true
 }
 
 resource "azurerm_storage_container" "tfstate" {
-    name = "tfstate"
-    storage_account_name = azurerm_storage_account.tfstate.name
+  name                 = "tfstate"
+  storage_account_name = azurerm_storage_account.tfstate.name
 }

--- a/terraform/1-network/gateway-vnet.tf
+++ b/terraform/1-network/gateway-vnet.tf
@@ -17,14 +17,14 @@ resource "azurerm_virtual_network" "gateway" {
 
 resource "azurerm_subnet" "gateway" {
   name                 = "GatewaySubnet"
-  resource_group_name = var.rg_gateway
+  resource_group_name  = var.rg_gateway
   virtual_network_name = azurerm_virtual_network.gateway.name
   address_prefixes     = [cidrsubnet(var.cidr_gateway, 8, 0)]
 }
 
 resource "azurerm_subnet" "resolver" {
   name                 = "ResolverSubnet"
-  resource_group_name = var.rg_gateway
+  resource_group_name  = var.rg_gateway
   virtual_network_name = azurerm_virtual_network.gateway.name
   address_prefixes     = [cidrsubnet(var.cidr_gateway, 8, 1)]
 
@@ -62,27 +62,27 @@ resource "azurerm_virtual_network_gateway" "gateway" {
 
   vpn_client_configuration {
     address_space = [var.cidr_vpn_gateway]
-    
-    vpn_client_protocols = [ "OpenVPN" ] # Must use with AAD
-    vpn_auth_types = [ "AAD" ]
-    aad_tenant = "https://login.microsoftonline.com/${var.tenant_id}/"
-    aad_audience = "41b23e61-6c1e-4545-b367-cd054e0ed4b4"
-    aad_issuer = "https://sts.windows.net/${var.tenant_id}/"
-    
-    
+
+    vpn_client_protocols = ["OpenVPN"] # Must use with AAD
+    vpn_auth_types       = ["AAD"]
+    aad_tenant           = "https://login.microsoftonline.com/${var.tenant_id}/"
+    aad_audience         = "41b23e61-6c1e-4545-b367-cd054e0ed4b4"
+    aad_issuer           = "https://sts.windows.net/${var.tenant_id}/"
+
+
   }
 
   custom_route {
-    address_prefixes = [ var.cidr_gateway, var.cidr_transit ]
+    address_prefixes = [var.cidr_gateway, var.cidr_transit]
   }
 
 }
 
 resource "azurerm_private_dns_resolver" "gateway" {
-  name = "pr-vnet-gateway"
+  name                = "pr-vnet-gateway"
   resource_group_name = var.rg_gateway
-  location = var.location
-  virtual_network_id = azurerm_virtual_network.gateway.id
+  location            = var.location
+  virtual_network_id  = azurerm_virtual_network.gateway.id
 }
 
 
@@ -101,7 +101,7 @@ resource "azurerm_virtual_network_peering" "gateway-transit" {
   resource_group_name       = var.rg_gateway
   virtual_network_name      = azurerm_virtual_network.gateway.name
   remote_virtual_network_id = azurerm_virtual_network.transit_vnet.id
-  allow_gateway_transit = true
+  allow_gateway_transit     = true
 }
 
 
@@ -110,13 +110,13 @@ resource "azurerm_virtual_network_peering" "transit-gateway" {
   resource_group_name       = var.rg_transit
   virtual_network_name      = azurerm_virtual_network.transit_vnet.name
   remote_virtual_network_id = azurerm_virtual_network.gateway.id
-  use_remote_gateways = true
-  allow_forwarded_traffic = true
+  use_remote_gateways       = true
+  allow_forwarded_traffic   = true
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "gateway" {
-    name                  = "dnslink-transit-gateway"
-    resource_group_name   = var.rg_transit
-    private_dns_zone_name = azurerm_private_dns_zone.dns_auth_front.name
-    virtual_network_id    = azurerm_virtual_network.gateway.id  
+  name                  = "dnslink-transit-gateway"
+  resource_group_name   = var.rg_transit
+  private_dns_zone_name = azurerm_private_dns_zone.dns_auth_front.name
+  virtual_network_id    = azurerm_virtual_network.gateway.id
 }

--- a/terraform/1-network/providers.tf
+++ b/terraform/1-network/providers.tf
@@ -7,11 +7,11 @@ terraform {
   }
 
   backend "azurerm" {
-    resource_group_name  = "rg-dbx-ml-tfstate"             # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
-    storage_account_name = "tfstateb563727617b12739"       # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
-    container_name       = "tfstate"                       # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
-    key                  = "network.terraform.tfstate"        # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
-    use_azuread_auth     = true                            # Can also be set via `ARM_USE_AZUREAD` environment variable.
+    resource_group_name  = "rg-dbx-ml-tfstate"         # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
+    storage_account_name = "tfstateb563727617b12739"   # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
+    container_name       = "tfstate"                   # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
+    key                  = "network.terraform.tfstate" # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
+    use_azuread_auth     = true                        # Can also be set via `ARM_USE_AZUREAD` environment variable.
 
   }
 }

--- a/terraform/1-network/vars.tf
+++ b/terraform/1-network/vars.tf
@@ -43,7 +43,7 @@ variable "location" {
 
 variable "tenant_id" {
   default = "6d2c78dd-1f85-4ccb-9ae3-cd5ea1cca361"
-  type = string
+  type    = string
 }
 
 data "azurerm_client_config" "current" {

--- a/terraform/2-workspace/data.tf
+++ b/terraform/2-workspace/data.tf
@@ -4,9 +4,9 @@ data "terraform_remote_state" "phase1_state" {
     tenant_id       = var.tenant_id
     subscription_id = var.subscription_id
 
-    resource_group_name                     = var.phase_1_state_backend_resource_group_name
-    storage_account_name                    = var.phase_1_state_backend_storage_account_name
-    container_name                          = var.phase_1_state_backend_container_name
-    key                                     = var.phase_1_state_backend_key_name
+    resource_group_name  = var.phase_1_state_backend_resource_group_name
+    storage_account_name = var.phase_1_state_backend_storage_account_name
+    container_name       = var.phase_1_state_backend_container_name
+    key                  = var.phase_1_state_backend_key_name
   }
 }

--- a/terraform/2-workspace/providers.tf
+++ b/terraform/2-workspace/providers.tf
@@ -7,11 +7,11 @@ terraform {
   }
 
   backend "azurerm" {
-    resource_group_name  = "rg-dbx-ml-tfstate"             # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
-    storage_account_name = "tfstateb563727617b12739"       # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
-    container_name       = "tfstate"                       # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
-    key                  = "workspace.terraform.tfstate"        # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
-    use_azuread_auth     = true                            # Can also be set via `ARM_USE_AZUREAD` environment variable.
+    resource_group_name  = "rg-dbx-ml-tfstate"           # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
+    storage_account_name = "tfstateb563727617b12739"     # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
+    container_name       = "tfstate"                     # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
+    key                  = "workspace.terraform.tfstate" # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
+    use_azuread_auth     = true                          # Can also be set via `ARM_USE_AZUREAD` environment variable.
 
   }
 }

--- a/terraform/2-workspace/vars.tf
+++ b/terraform/2-workspace/vars.tf
@@ -39,12 +39,12 @@ variable "location" {
 
 variable "tenant_id" {
   default = "6d2c78dd-1f85-4ccb-9ae3-cd5ea1cca361"
-  type = string
+  type    = string
 }
 
 variable "subscription_id" {
   default = "972bbe39-991c-4055-80b8-ab36598f89c3"
-  type = string
+  type    = string
 }
 
 data "azurerm_client_config" "current" {

--- a/terraform/3-databricks/providers.tf
+++ b/terraform/3-databricks/providers.tf
@@ -6,17 +6,17 @@ terraform {
     }
 
     databricks = {
-      source  = "databricks/databricks" 
+      source  = "databricks/databricks"
       version = "1.64.1"
     }
   }
 
   backend "azurerm" {
-    resource_group_name  = "rg-dbx-ml-tfstate"             # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
-    storage_account_name = "tfstateb563727617b12739"       # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
-    container_name       = "tfstate"                       # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
-    key                  = "databricks.terraform.tfstate"  # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
-    use_azuread_auth     = true                            # Can also be set via `ARM_USE_AZUREAD` environment variable.
+    resource_group_name  = "rg-dbx-ml-tfstate"            # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
+    storage_account_name = "tfstateb563727617b12739"      # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
+    container_name       = "tfstate"                      # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
+    key                  = "databricks.terraform.tfstate" # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
+    use_azuread_auth     = true                           # Can also be set via `ARM_USE_AZUREAD` environment variable.
 
   }
 }

--- a/terraform/3-databricks/sql-warehouses.tf
+++ b/terraform/3-databricks/sql-warehouses.tf
@@ -1,7 +1,7 @@
 resource "databricks_sql_endpoint" "serverless-main" {
-    name = "serverless-main"
-    cluster_size = "2X-Small"
-    warehouse_type = "PRO"
-    auto_stop_mins = 10
-    enable_serverless_compute = true
+  name                      = "serverless-main"
+  cluster_size              = "2X-Small"
+  warehouse_type            = "PRO"
+  auto_stop_mins            = 10
+  enable_serverless_compute = true
 }

--- a/terraform/3-databricks/vars.tf
+++ b/terraform/3-databricks/vars.tf
@@ -1,4 +1,4 @@
 variable "workspace_url" {
   default = "https://adb-696792267492982.2.azuredatabricks.net"
-  type = string
+  type    = string
 }


### PR DESCRIPTION
Closes #2

Adds `.github/workflows/terraform-fmt.yml` which runs `terraform fmt -check -recursive` from the repo root on every pull request targeting `main`, ensuring all Terraform code stays consistently formatted before merge.

The workflow pins Terraform to `1.9.8` via `hashicorp/setup-terraform@v3` and disables the wrapper so the exit code of `terraform fmt -check` propagates directly to the job.

This is the first CI workflow for the repo; issues #3 (`terraform validate`) and #4 (`tflint`) will extend it with further checks.