### PR TITLE
Add `terraform validate` step to CI workflow

### DIFF
--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -1,0 +1,35 @@
+name: terraform-validate
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  validate:
+    name: terraform validate
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        stage:
+          - terraform/0-structure
+          - terraform/1-network
+          - terraform/2-workspace
+          - terraform/3-databricks
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.9.8
+          terraform_wrapper: false
+
+      - name: Terraform init (no backend)
+        run: terraform init -backend=false
+        working-directory: ${{ matrix.stage }}
+
+      - name: Terraform validate
+        run: terraform validate
+        working-directory: ${{ matrix.stage }}

--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -27,7 +27,7 @@ jobs:
           terraform_wrapper: false
 
       - name: Terraform init (no backend)
-        run: terraform init -backend=false
+        run: terraform init -backend=false -upgrade
         working-directory: ${{ matrix.stage }}
 
       - name: Terraform validate


### PR DESCRIPTION
Closes #3

Adds `.github/workflows/terraform-validate.yml` — a new CI workflow that runs `terraform init -backend=false` followed by `terraform validate` for each of the four stage directories (`0-structure`, `1-network`, `2-workspace`, `3-databricks`) in a matrix job on every PR targeting `main`. Uses the same Terraform version (1.9.8) as the existing `terraform-fmt` workflow.