### PR TITLE
Parameterise `subscription_id` and `tenant_id` in stage 0

### DIFF
--- a/terraform/0-structure/providers.tf
+++ b/terraform/0-structure/providers.tf
@@ -8,7 +8,8 @@ terraform {
 }
 
 provider "azurerm" {
-  subscription_id = "972bbe39-991c-4055-80b8-ab36598f89c3" # VSES – MPN - Peter Sach
+  subscription_id = var.subscription_id
+  tenant_id       = var.tenant_id
   features {}
 }
 

--- a/terraform/0-structure/structure.md
+++ b/terraform/0-structure/structure.md
@@ -6,3 +6,12 @@ The purpose of this Terraform project is to be run seperately and before all the
 
 You need to grant RBAC permission on this storage container after creation. (Could Automate?!)
 
+## Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `subscription_id` | `972bbe39-991c-4055-80b8-ab36598f89c3` | Azure subscription ID |
+| `tenant_id` | `6d2c78dd-1f85-4ccb-9ae3-cd5ea1cca361` | Azure Entra ID tenant ID |
+
+Override these at plan/apply time with `-var` flags or a `.tfvars` file when targeting a different subscription or tenant.
+

--- a/terraform/0-structure/vars.tf
+++ b/terraform/0-structure/vars.tf
@@ -1,3 +1,13 @@
+variable "subscription_id" {
+  type    = string
+  default = "972bbe39-991c-4055-80b8-ab36598f89c3"
+}
+
+variable "tenant_id" {
+  type    = string
+  default = "6d2c78dd-1f85-4ccb-9ae3-cd5ea1cca361"
+}
+
 variable "rg_tfstate" {
   default = "rg-dbx-ml-tfstate"
   type    = string


### PR DESCRIPTION
Closes #5

Moves the hard-coded `subscription_id` and `tenant_id` values out of `providers.tf` and into `vars.tf` as variables with the current values as defaults, so existing deployments require no workflow change. Updates `structure.md` with a variables table explaining how to override them.

---
_Generated by [Claude Code](https://claude.ai/code/session_017WdULsPrqANCioLrX4ZvBP)_