### PR TITLE
Parameterise `subscription_id` and `tenant_id` in stages 1–3

### DIFF
--- a/terraform/1-network/providers.tf
+++ b/terraform/1-network/providers.tf
@@ -17,7 +17,8 @@ terraform {
 }
 
 provider "azurerm" {
-  subscription_id = "972bbe39-991c-4055-80b8-ab36598f89c3" # VSES – MPN - Peter Sach
+  subscription_id = var.subscription_id
+  tenant_id       = var.tenant_id
   features {}
 }
 

--- a/terraform/1-network/vars.tf
+++ b/terraform/1-network/vars.tf
@@ -41,9 +41,14 @@ variable "location" {
   type    = string
 }
 
-variable "tenant_id" {
-  default = "6d2c78dd-1f85-4ccb-9ae3-cd5ea1cca361"
+variable "subscription_id" {
   type    = string
+  default = "972bbe39-991c-4055-80b8-ab36598f89c3"
+}
+
+variable "tenant_id" {
+  type    = string
+  default = "6d2c78dd-1f85-4ccb-9ae3-cd5ea1cca361"
 }
 
 data "azurerm_client_config" "current" {

--- a/terraform/2-workspace/providers.tf
+++ b/terraform/2-workspace/providers.tf
@@ -18,6 +18,7 @@ terraform {
 
 provider "azurerm" {
   subscription_id = var.subscription_id
+  tenant_id       = var.tenant_id
   features {}
 }
 

--- a/terraform/3-databricks/vars.tf
+++ b/terraform/3-databricks/vars.tf
@@ -1,3 +1,13 @@
+variable "subscription_id" {
+  type    = string
+  default = "972bbe39-991c-4055-80b8-ab36598f89c3"
+}
+
+variable "tenant_id" {
+  type    = string
+  default = "6d2c78dd-1f85-4ccb-9ae3-cd5ea1cca361"
+}
+
 variable "workspace_url" {
   default = "https://adb-696792267492982.2.azuredatabricks.net"
   type    = string


### PR DESCRIPTION
Closes #6

Repeats the parameterisation pattern introduced in #5 across stages 1–3:

- **Stage 1 (`1-network`)**: Added `subscription_id` variable to `vars.tf`; updated `providers.tf` to reference `var.subscription_id` and `var.tenant_id` instead of the hard-coded string.
- **Stage 2 (`2-workspace`)**: Variables were already present in `vars.tf`; added `tenant_id = var.tenant_id` to the provider block to match the stage 0 pattern.
- **Stage 3 (`3-databricks`)**: No azurerm provider to update, but added `subscription_id` and `tenant_id` variables to `vars.tf` for consistency.

All existing variable defaults are preserved so no live deployment requires any workflow change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GFCLfY2dCsFPWp7UNVZE9q)_