### PR TITLE
Parameterise `environment` tag value across all stages

### DIFF
--- a/terraform/0-structure/vars.tf
+++ b/terraform/0-structure/vars.tf
@@ -23,6 +23,11 @@ variable "tfstate_account_replication_type" {
   type    = string
 }
 
+variable "environment" {
+  type    = string
+  default = "Demo"
+}
+
 locals {
   rg_tfstate   = "rg-${var.naming_prefix}-tfstate"
   rg_gateway   = "rg-${var.naming_prefix}-gateway"

--- a/terraform/1-network/vars.tf
+++ b/terraform/1-network/vars.tf
@@ -39,6 +39,11 @@ variable "tenant_id" {
   default = "6d2c78dd-1f85-4ccb-9ae3-cd5ea1cca361"
 }
 
+variable "environment" {
+  type    = string
+  default = "Demo"
+}
+
 data "azurerm_client_config" "current" {
 }
 
@@ -56,7 +61,7 @@ locals {
   prefix   = "${var.naming_prefix}ops"
   dbfsname = join("", ["dbfs", "${random_string.naming.result}"])
   tags = {
-    Environment = "Demo"
+    Environment = var.environment
     Owner       = lookup(data.external.me.result, "name")
   }
   rg_gateway   = "rg-${var.naming_prefix}-gateway"

--- a/terraform/2-workspace/vars.tf
+++ b/terraform/2-workspace/vars.tf
@@ -42,6 +42,11 @@ variable "subscription_id" {
   type    = string
 }
 
+variable "environment" {
+  type    = string
+  default = "Demo"
+}
+
 data "azurerm_client_config" "current" {
 }
 
@@ -59,7 +64,7 @@ locals {
   prefix   = var.naming_prefix
   dbfsname = join("", ["dbfs", "${random_string.naming.result}"])
   tags = {
-    Environment = "Demo"
+    Environment = var.environment
     Owner       = lookup(data.external.me.result, "name")
   }
   rg_transit   = "rg-${var.naming_prefix}-transit"

--- a/terraform/3-databricks/vars.tf
+++ b/terraform/3-databricks/vars.tf
@@ -17,3 +17,8 @@ variable "workspace_url" {
   default = "https://adb-696792267492982.2.azuredatabricks.net"
   type    = string
 }
+
+variable "environment" {
+  type    = string
+  default = "Demo"
+}


### PR DESCRIPTION
Closes #8

Added `variable "environment"` (type string, default `"Demo"`) to all four stage `vars.tf` files. Updated the `tags` locals block in stages 1 and 2 to reference `var.environment` instead of the hard-coded `"Demo"` string. Stages 0 and 3 receive the variable for consistency but have no `tags` locals block to update.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FgbkqpWNPwax1fCSRUEoXw)_