### PR TITLE
Add per-environment backend config files to stages 1–3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 *.tfvars
 *.tfvars.json
 
+# Per-environment backend config (use backend.conf.example as a template)
+backend.conf
+
 # Crash log files
 crash.log
 

--- a/terraform/1-network/backend.conf.example
+++ b/terraform/1-network/backend.conf.example
@@ -1,0 +1,5 @@
+resource_group_name  = "rg-dbx-ml-tfstate"
+storage_account_name = "tfstateb563727617b12739"
+container_name       = "tfstate"
+key                  = "network.terraform.tfstate"
+use_azuread_auth     = true

--- a/terraform/1-network/network.md
+++ b/terraform/1-network/network.md
@@ -1,5 +1,17 @@
 # Network
 
+## Deployment
+
+Copy `backend.conf.example` to `backend.conf` and fill in the values for your environment, then initialise Terraform:
+
+```bash
+cp backend.conf.example backend.conf
+terraform init -backend-config=backend.conf
+terraform apply
+```
+
+`backend.conf` is excluded from version control via `.gitignore`.
+
 This stage uses the resource groups in the previous stage and uses them to setup the infrastructure for the network, the network itself is split into 3 parts:
 - Gateway - The gateway network allows users to log on to the platform
 - Transit - The transit network is the way users can access Databricks.

--- a/terraform/1-network/providers.tf
+++ b/terraform/1-network/providers.tf
@@ -6,14 +6,7 @@ terraform {
     }
   }
 
-  backend "azurerm" {
-    resource_group_name  = "rg-dbx-ml-tfstate"         # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
-    storage_account_name = "tfstateb563727617b12739"   # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
-    container_name       = "tfstate"                   # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
-    key                  = "network.terraform.tfstate" # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
-    use_azuread_auth     = true                        # Can also be set via `ARM_USE_AZUREAD` environment variable.
-
-  }
+  backend "azurerm" {}
 }
 
 provider "azurerm" {

--- a/terraform/2-workspace/backend.conf.example
+++ b/terraform/2-workspace/backend.conf.example
@@ -1,0 +1,5 @@
+resource_group_name  = "rg-dbx-ml-tfstate"
+storage_account_name = "tfstateb563727617b12739"
+container_name       = "tfstate"
+key                  = "workspace.terraform.tfstate"
+use_azuread_auth     = true

--- a/terraform/2-workspace/providers.tf
+++ b/terraform/2-workspace/providers.tf
@@ -6,14 +6,7 @@ terraform {
     }
   }
 
-  backend "azurerm" {
-    resource_group_name  = "rg-dbx-ml-tfstate"           # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
-    storage_account_name = "tfstateb563727617b12739"     # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
-    container_name       = "tfstate"                     # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
-    key                  = "workspace.terraform.tfstate" # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
-    use_azuread_auth     = true                          # Can also be set via `ARM_USE_AZUREAD` environment variable.
-
-  }
+  backend "azurerm" {}
 }
 
 provider "azurerm" {

--- a/terraform/2-workspace/workspace.md
+++ b/terraform/2-workspace/workspace.md
@@ -1,5 +1,17 @@
 # Workspace Config
 
+## Deployment
+
+Copy `backend.conf.example` to `backend.conf` and fill in the values for your environment, then initialise Terraform:
+
+```bash
+cp backend.conf.example backend.conf
+terraform init -backend-config=backend.conf
+terraform apply
+```
+
+`backend.conf` is excluded from version control via `.gitignore`.
+
 Now we have the networks in place, we can add our Databricks Infrastructure. This stage deploys our 2 databricks workspaces, and the endpoints used to provide access to them. Our main workspace is our "app-workspace" and that is the one our users will connect to. We also have an "auth-workspace" which is a redundant workspace that provides authorization of users and sits in our Transit VNet.
 
 

--- a/terraform/3-databricks/backend.conf.example
+++ b/terraform/3-databricks/backend.conf.example
@@ -1,0 +1,5 @@
+resource_group_name  = "rg-dbx-ml-tfstate"
+storage_account_name = "tfstateb563727617b12739"
+container_name       = "tfstate"
+key                  = "databricks.terraform.tfstate"
+use_azuread_auth     = true

--- a/terraform/3-databricks/databricks.md
+++ b/terraform/3-databricks/databricks.md
@@ -1,5 +1,17 @@
 # Databricks Workspace Setup
 
+## Deployment
+
+Copy `backend.conf.example` to `backend.conf` and fill in the values for your environment, then initialise Terraform:
+
+```bash
+cp backend.conf.example backend.conf
+terraform init -backend-config=backend.conf
+terraform apply -var="workspace_url=https://<workspace>.azuredatabricks.net"
+```
+
+`backend.conf` is excluded from version control via `.gitignore`.
+
 This stage of the Terraform Pipeline is to govern the deployment of resources within Databricks itself. This includes things such as clusters, sql warehouses, workspace settings.
 
 Depending on your setup, you may include Unity Catalog objects and permissions within this step, however I would suggest that they are separated out into their own projects (Unity is not tightly tied to an individual workspace.)

--- a/terraform/3-databricks/providers.tf
+++ b/terraform/3-databricks/providers.tf
@@ -11,14 +11,7 @@ terraform {
     }
   }
 
-  backend "azurerm" {
-    resource_group_name  = "rg-dbx-ml-tfstate"            # Can be passed via `-backend-config=`"resource_group_name=<resource group name>"` in the `init` command.
-    storage_account_name = "tfstateb563727617b12739"      # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
-    container_name       = "tfstate"                      # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
-    key                  = "databricks.terraform.tfstate" # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
-    use_azuread_auth     = true                           # Can also be set via `ARM_USE_AZUREAD` environment variable.
-
-  }
+  backend "azurerm" {}
 }
 
 provider "databricks" {


### PR DESCRIPTION
Closes #9

Replace inline backend values in each stage's `providers.tf` with an empty `backend "azurerm" {}` block. Add a `backend.conf.example` file per stage (stages 1–3) that documents the current hard-coded values. Update each stage's markdown doc to show the `terraform init -backend-config=backend.conf` workflow. Add `backend.conf` to the root `.gitignore` to prevent accidental commits of real backend config.

---
_Generated by [Claude Code](https://claude.ai/code/session_013JdjccyRygS3wvC2b8GJ2v)_