### PR TITLE
Add consumption budget per resource group in stage 0

### DIFF
--- a/terraform/0-structure/budgets.tf
+++ b/terraform/0-structure/budgets.tf
@@ -1,0 +1,75 @@
+#####################
+##  COST BUDGETS   ##
+#####################
+
+resource "azurerm_consumption_budget_resource_group" "gateway" {
+  name              = "budget-${local.rg_gateway}"
+  resource_group_id = azurerm_resource_group.gateway.id
+  amount            = var.monthly_budget_usd
+  time_grain        = "Monthly"
+
+  time_period {
+    start_date = "2024-01-01T00:00:00Z"
+  }
+
+  notification {
+    enabled       = true
+    threshold     = 100
+    operator      = "EqualTo"
+    contact_roles = ["Owner"]
+  }
+}
+
+resource "azurerm_consumption_budget_resource_group" "transit" {
+  name              = "budget-${local.rg_transit}"
+  resource_group_id = azurerm_resource_group.transit.id
+  amount            = var.monthly_budget_usd
+  time_grain        = "Monthly"
+
+  time_period {
+    start_date = "2024-01-01T00:00:00Z"
+  }
+
+  notification {
+    enabled       = true
+    threshold     = 100
+    operator      = "EqualTo"
+    contact_roles = ["Owner"]
+  }
+}
+
+resource "azurerm_consumption_budget_resource_group" "dataplane" {
+  name              = "budget-${local.rg_dataplane}"
+  resource_group_id = azurerm_resource_group.dataplane.id
+  amount            = var.monthly_budget_usd
+  time_grain        = "Monthly"
+
+  time_period {
+    start_date = "2024-01-01T00:00:00Z"
+  }
+
+  notification {
+    enabled       = true
+    threshold     = 100
+    operator      = "EqualTo"
+    contact_roles = ["Owner"]
+  }
+}
+
+resource "azurerm_consumption_budget_resource_group" "tfstate" {
+  name              = "budget-${local.rg_tfstate}"
+  resource_group_id = azurerm_resource_group.tfstate.id
+  amount            = var.monthly_budget_usd
+  time_grain        = "Monthly"
+
+  time_period {
+    start_date = "2024-01-01T00:00:00Z"
+  }
+
+  notification {
+    enabled       = true
+    threshold     = 100
+    operator      = "EqualTo"
+    contact_roles = ["Owner"]
+  }
+}

--- a/terraform/0-structure/vars.tf
+++ b/terraform/0-structure/vars.tf
@@ -28,6 +28,11 @@ variable "environment" {
   default = "Demo"
 }
 
+variable "monthly_budget_usd" {
+  type    = number
+  default = 100
+}
+
 locals {
   rg_tfstate   = "rg-${var.naming_prefix}-tfstate"
   rg_gateway   = "rg-${var.naming_prefix}-gateway"


### PR DESCRIPTION
Closes #10

Adds `azurerm_consumption_budget_resource_group` resources in `terraform/0-structure/budgets.tf` for each of the four resource groups (gateway, transit, dataplane, tfstate).

- New `monthly_budget_usd` variable (default `100`) controls the budget amount for all four resource groups.
- Each budget uses `time_grain = "Monthly"` and a `100` threshold notification via `contact_roles = ["Owner"]`, which alerts whoever holds the Owner role on the resource group (inheriting subscription owners).

---
_Generated by [Claude Code](https://claude.ai/code/session_018p1348GkNNxBHhBJGjaRek)_