### PR TITLE
Add `deploy_vpn_gateway` toggle to stage 1

### DIFF
--- a/terraform/1-network/gateway-vnet.tf
+++ b/terraform/1-network/gateway-vnet.tf
@@ -38,6 +38,7 @@ resource "azurerm_subnet" "resolver" {
 }
 
 resource "azurerm_public_ip" "gateway" {
+  count               = var.deploy_vpn_gateway ? 1 : 0
   name                = "ip-${var.naming_prefix}-gateway"
   resource_group_name = local.rg_gateway
   location            = var.location
@@ -45,6 +46,7 @@ resource "azurerm_public_ip" "gateway" {
 }
 
 resource "azurerm_virtual_network_gateway" "gateway" {
+  count               = var.deploy_vpn_gateway ? 1 : 0
   name                = "vng-${var.naming_prefix}-gateway"
   resource_group_name = local.rg_gateway
   location            = var.location
@@ -55,7 +57,7 @@ resource "azurerm_virtual_network_gateway" "gateway" {
 
   ip_configuration {
     name                          = "vng-${var.naming_prefix}-gateway-ipconfig"
-    public_ip_address_id          = azurerm_public_ip.gateway.id
+    public_ip_address_id          = azurerm_public_ip.gateway[0].id
     subnet_id                     = azurerm_subnet.gateway.id
     private_ip_address_allocation = "Dynamic"
   }
@@ -101,7 +103,7 @@ resource "azurerm_virtual_network_peering" "gateway-transit" {
   resource_group_name       = local.rg_gateway
   virtual_network_name      = azurerm_virtual_network.gateway.name
   remote_virtual_network_id = azurerm_virtual_network.transit_vnet.id
-  allow_gateway_transit     = true
+  allow_gateway_transit     = var.deploy_vpn_gateway
 }
 
 
@@ -110,7 +112,7 @@ resource "azurerm_virtual_network_peering" "transit-gateway" {
   resource_group_name       = local.rg_transit
   virtual_network_name      = azurerm_virtual_network.transit_vnet.name
   remote_virtual_network_id = azurerm_virtual_network.gateway.id
-  use_remote_gateways       = true
+  use_remote_gateways       = var.deploy_vpn_gateway
   allow_forwarded_traffic   = true
 }
 

--- a/terraform/1-network/network.md
+++ b/terraform/1-network/network.md
@@ -22,6 +22,12 @@ By using this approach we can more easily represent what we might see on a clien
 - You will likely need to set up the other 2 parts of the network. Having an understanding of each will allow you to effectively communicate with a client what is required from each.
 
 
+## Optional Toggles
+
+### `deploy_vpn_gateway` (default: `true`)
+
+Set this variable to `false` to skip deploying the VPN gateway and its public IP. This is intended for customer hub-and-spoke environments where a VPN gateway already exists in a shared connectivity hub — in those cases the P2S gateway in this stage is redundant and would incur unnecessary cost. When the toggle is disabled the VNet peering between the gateway and transit VNets remains in place but `allow_gateway_transit` / `use_remote_gateways` are set to `false`, so no gateway routes are propagated.
+
 ## Gateway Network
 
 Our Gateway network contains only 4 resources, but in a way it is the most complex piece of networking included in this project.

--- a/terraform/1-network/vars.tf
+++ b/terraform/1-network/vars.tf
@@ -44,6 +44,11 @@ variable "environment" {
   default = "Demo"
 }
 
+variable "deploy_vpn_gateway" {
+  type    = bool
+  default = true
+}
+
 data "azurerm_client_config" "current" {
 }
 


### PR DESCRIPTION
Closes #11

Adds a `deploy_vpn_gateway` boolean variable (default `true`) to `terraform/1-network/` that makes the P2S VPN gateway optional.

**What changed:**
- `vars.tf`: new `deploy_vpn_gateway` variable (default `true`, preserving existing behaviour)
- `gateway-vnet.tf`: `azurerm_public_ip.gateway` and `azurerm_virtual_network_gateway.gateway` (which contains the `vpn_client_configuration` block) are now guarded with `count = var.deploy_vpn_gateway ? 1 : 0`; the internal public-IP reference is updated to `[0]` accordingly; VNet peering attributes `allow_gateway_transit` and `use_remote_gateways` are set dynamically from the toggle so the peering remains valid when the gateway is absent
- `network.md`: documents the toggle and explains the hub-and-spoke use case

---
_Generated by [Claude Code](https://claude.ai/code/session_01BwfaxpSLrKvR2ostZTD94W)_