### PR TITLE
Add `deploy_private_resolver` toggle to stage 1

### DIFF
--- a/terraform/1-network/gateway-vnet.tf
+++ b/terraform/1-network/gateway-vnet.tf
@@ -23,6 +23,7 @@ resource "azurerm_subnet" "gateway" {
 }
 
 resource "azurerm_subnet" "resolver" {
+  count                = var.deploy_private_resolver ? 1 : 0
   name                 = "ResolverSubnet"
   resource_group_name  = local.rg_gateway
   virtual_network_name = azurerm_virtual_network.gateway.name
@@ -81,6 +82,7 @@ resource "azurerm_virtual_network_gateway" "gateway" {
 }
 
 resource "azurerm_private_dns_resolver" "gateway" {
+  count               = var.deploy_private_resolver ? 1 : 0
   name                = "pr-vnet-gateway"
   resource_group_name = local.rg_gateway
   location            = var.location
@@ -89,12 +91,13 @@ resource "azurerm_private_dns_resolver" "gateway" {
 
 
 resource "azurerm_private_dns_resolver_inbound_endpoint" "gateway" {
+  count                   = var.deploy_private_resolver ? 1 : 0
   name                    = "PE_RESOLVER_IB"
-  private_dns_resolver_id = azurerm_private_dns_resolver.gateway.id
+  private_dns_resolver_id = azurerm_private_dns_resolver.gateway[0].id
   location                = var.location
   ip_configurations {
     private_ip_allocation_method = "Dynamic"
-    subnet_id                    = azurerm_subnet.resolver.id
+    subnet_id                    = azurerm_subnet.resolver[0].id
   }
 }
 

--- a/terraform/1-network/network.md
+++ b/terraform/1-network/network.md
@@ -28,6 +28,10 @@ By using this approach we can more easily represent what we might see on a clien
 
 Set this variable to `false` to skip deploying the VPN gateway and its public IP. This is intended for customer hub-and-spoke environments where a VPN gateway already exists in a shared connectivity hub — in those cases the P2S gateway in this stage is redundant and would incur unnecessary cost. When the toggle is disabled the VNet peering between the gateway and transit VNets remains in place but `allow_gateway_transit` / `use_remote_gateways` are set to `false`, so no gateway routes are propagated.
 
+### `deploy_private_resolver` (default: `true`)
+
+Set this variable to `false` to skip deploying the Azure Private DNS Resolver (and its inbound endpoint and delegated subnet) in the gateway VNet. In customer environments that already have a DNS infrastructure — such as on-premises DNS servers forwarding to Azure — conditional forwarders on those DNS servers can be configured to point `privatelink.azuredatabricks.net` queries directly at the private DNS zone inbound IP, replacing the resolver entirely. Disabling this toggle avoids deploying a duplicate resolver that would conflict with the existing DNS hierarchy.
+
 ## Gateway Network
 
 Our Gateway network contains only 4 resources, but in a way it is the most complex piece of networking included in this project.

--- a/terraform/1-network/vars.tf
+++ b/terraform/1-network/vars.tf
@@ -49,6 +49,11 @@ variable "deploy_vpn_gateway" {
   default = true
 }
 
+variable "deploy_private_resolver" {
+  type    = bool
+  default = true
+}
+
 data "azurerm_client_config" "current" {
 }
 


### PR DESCRIPTION
Closes #12

Added a `deploy_private_resolver` boolean variable (default `true`) to `terraform/1-network/`. When set to `false`, the `azurerm_subnet.resolver`, `azurerm_private_dns_resolver.gateway`, and `azurerm_private_dns_resolver_inbound_endpoint.gateway` resources are skipped via `count = 0`. Updated `network.md` to document the toggle and explain the alternative: configuring conditional forwarders on an existing on-premises DNS server to forward `privatelink.azuredatabricks.net` queries to the private DNS zone, replacing the need for the Azure Private DNS Resolver.

---
_Generated by [Claude Code](https://claude.ai/code/session_014NzAwupo4VHRAHUgeRE3nZ)_