### PR TITLE
Extract workspace + VNet injection into a reusable module

### DIFF
--- a/terraform/2-workspace/app-workspace.tf
+++ b/terraform/2-workspace/app-workspace.tf
@@ -1,21 +1,16 @@
-resource "azurerm_databricks_workspace" "app_workspace" {
-  name                                  = "${local.prefix}-app-workspace"
-  resource_group_name                   = local.rg_dataplane
-  location                              = var.location
-  sku                                   = "premium"
-  tags                                  = local.tags
-  public_network_access_enabled         = false                    //use private endpoint
-  network_security_group_rules_required = "NoAzureDatabricksRules" //use private endpoint
-  customer_managed_key_enabled          = true
-  custom_parameters {
-    no_public_ip                                         = true
-    virtual_network_id                                   = data.terraform_remote_state.phase1_state.outputs.app_vnet_id
-    private_subnet_name                                  = data.terraform_remote_state.phase1_state.outputs.subnet_app_private_name
-    public_subnet_name                                   = data.terraform_remote_state.phase1_state.outputs.subnet_app_public_name
-    public_subnet_network_security_group_association_id  = data.terraform_remote_state.phase1_state.outputs.nsg_app_public_id
-    private_subnet_network_security_group_association_id = data.terraform_remote_state.phase1_state.outputs.nsg_app_private_id
-    storage_account_name                                 = "dbfsapphj32ui4"
-  }
+module "app_workspace" {
+  source = "../modules/databricks-workspace"
+
+  workspace_name        = "${local.prefix}-app-workspace"
+  resource_group_name   = local.rg_dataplane
+  location              = var.location
+  vnet_id               = data.terraform_remote_state.phase1_state.outputs.app_vnet_id
+  public_subnet_name    = data.terraform_remote_state.phase1_state.outputs.subnet_app_public_name
+  private_subnet_name   = data.terraform_remote_state.phase1_state.outputs.subnet_app_private_name
+  public_subnet_nsg_id  = data.terraform_remote_state.phase1_state.outputs.nsg_app_public_id
+  private_subnet_nsg_id = data.terraform_remote_state.phase1_state.outputs.nsg_app_private_id
+  storage_account_name  = "dbfsapphj32ui4"
+  tags                  = local.tags
 }
 
 ###
@@ -30,7 +25,7 @@ resource "azurerm_private_endpoint" "app_dpcp" {
 
   private_service_connection {
     name                           = "ple-${local.prefix}-dpcp"
-    private_connection_resource_id = azurerm_databricks_workspace.app_workspace.id
+    private_connection_resource_id = module.app_workspace.workspace_id
     is_manual_connection           = false
     subresource_names              = ["databricks_ui_api"]
   }

--- a/terraform/2-workspace/auth-workspace.tf
+++ b/terraform/2-workspace/auth-workspace.tf
@@ -1,22 +1,16 @@
+module "auth_workspace" {
+  source = "../modules/databricks-workspace"
 
-resource "azurerm_databricks_workspace" "web_auth_workspace" {
-  name                                  = "${local.prefix}-transit-workspace"
-  resource_group_name                   = local.rg_transit
-  location                              = var.location
-  sku                                   = "premium"
-  tags                                  = local.tags
-  public_network_access_enabled         = false                    //use private endpoint
-  network_security_group_rules_required = "NoAzureDatabricksRules" //use private endpoint
-  customer_managed_key_enabled          = true
-  custom_parameters {
-    no_public_ip                                         = true
-    virtual_network_id                                   = data.terraform_remote_state.phase1_state.outputs.transit_vnet_id
-    private_subnet_name                                  = data.terraform_remote_state.phase1_state.outputs.subnet_transit_private_name
-    public_subnet_name                                   = data.terraform_remote_state.phase1_state.outputs.subnet_transit_public_name
-    public_subnet_network_security_group_association_id  = data.terraform_remote_state.phase1_state.outputs.nsg_transit_public_id
-    private_subnet_network_security_group_association_id = data.terraform_remote_state.phase1_state.outputs.nsg_transit_private_id
-    storage_account_name                                 = local.dbfsname
-  }
+  workspace_name        = "${local.prefix}-transit-workspace"
+  resource_group_name   = local.rg_transit
+  location              = var.location
+  vnet_id               = data.terraform_remote_state.phase1_state.outputs.transit_vnet_id
+  public_subnet_name    = data.terraform_remote_state.phase1_state.outputs.subnet_transit_public_name
+  private_subnet_name   = data.terraform_remote_state.phase1_state.outputs.subnet_transit_private_name
+  public_subnet_nsg_id  = data.terraform_remote_state.phase1_state.outputs.nsg_transit_public_id
+  private_subnet_nsg_id = data.terraform_remote_state.phase1_state.outputs.nsg_transit_private_id
+  storage_account_name  = local.dbfsname
+  tags                  = local.tags
 }
 
 
@@ -32,7 +26,7 @@ resource "azurerm_private_endpoint" "front_pe" {
 
   private_service_connection {
     name                           = "ple-${local.prefix}-uiapi"
-    private_connection_resource_id = azurerm_databricks_workspace.app_workspace.id
+    private_connection_resource_id = module.app_workspace.workspace_id
     is_manual_connection           = false
     subresource_names              = ["databricks_ui_api"]
   }
@@ -52,7 +46,7 @@ resource "azurerm_private_endpoint" "transit_auth" {
 
   private_service_connection {
     name                           = "ple-${local.prefix}-auth"
-    private_connection_resource_id = azurerm_databricks_workspace.web_auth_workspace.id
+    private_connection_resource_id = module.auth_workspace.workspace_id
     is_manual_connection           = false
     subresource_names              = ["browser_authentication"]
   }
@@ -62,7 +56,3 @@ resource "azurerm_private_endpoint" "transit_auth" {
     private_dns_zone_ids = [data.terraform_remote_state.phase1_state.outputs.dns_auth_front_id]
   }
 }
-
-
-
-

--- a/terraform/2-workspace/outputs.tf
+++ b/terraform/2-workspace/outputs.tf
@@ -1,3 +1,3 @@
 output "app_workspace_url" {
-  value = azurerm_databricks_workspace.app_workspace.workspace_url
+  value = module.app_workspace.workspace_url
 }

--- a/terraform/modules/databricks-workspace/main.tf
+++ b/terraform/modules/databricks-workspace/main.tf
@@ -1,0 +1,20 @@
+resource "azurerm_databricks_workspace" "this" {
+  name                                  = var.workspace_name
+  resource_group_name                   = var.resource_group_name
+  location                              = var.location
+  sku                                   = var.sku
+  tags                                  = var.tags
+  public_network_access_enabled         = false
+  network_security_group_rules_required = "NoAzureDatabricksRules"
+  customer_managed_key_enabled          = true
+
+  custom_parameters {
+    no_public_ip                                         = var.no_public_ip
+    virtual_network_id                                   = var.vnet_id
+    public_subnet_name                                   = var.public_subnet_name
+    private_subnet_name                                  = var.private_subnet_name
+    public_subnet_network_security_group_association_id  = var.public_subnet_nsg_id
+    private_subnet_network_security_group_association_id = var.private_subnet_nsg_id
+    storage_account_name                                 = var.storage_account_name
+  }
+}

--- a/terraform/modules/databricks-workspace/outputs.tf
+++ b/terraform/modules/databricks-workspace/outputs.tf
@@ -1,0 +1,9 @@
+output "workspace_id" {
+  description = "Resource ID of the Databricks workspace"
+  value       = azurerm_databricks_workspace.this.id
+}
+
+output "workspace_url" {
+  description = "Workspace URL of the Databricks workspace"
+  value       = azurerm_databricks_workspace.this.workspace_url
+}

--- a/terraform/modules/databricks-workspace/variables.tf
+++ b/terraform/modules/databricks-workspace/variables.tf
@@ -1,0 +1,62 @@
+variable "workspace_name" {
+  type        = string
+  description = "Name of the Databricks workspace"
+}
+
+variable "resource_group_name" {
+  type        = string
+  description = "Name of the resource group to deploy the workspace into"
+}
+
+variable "location" {
+  type        = string
+  description = "Azure region for the workspace"
+}
+
+variable "vnet_id" {
+  type        = string
+  description = "Resource ID of the VNet for VNet injection"
+}
+
+variable "public_subnet_name" {
+  type        = string
+  description = "Name of the public (container) subnet for VNet injection"
+}
+
+variable "private_subnet_name" {
+  type        = string
+  description = "Name of the private (host) subnet for VNet injection"
+}
+
+variable "public_subnet_nsg_id" {
+  type        = string
+  description = "Resource ID of the NSG association on the public subnet"
+}
+
+variable "private_subnet_nsg_id" {
+  type        = string
+  description = "Resource ID of the NSG association on the private subnet"
+}
+
+variable "storage_account_name" {
+  type        = string
+  description = "Name of the DBFS root storage account (must be globally unique, 3-24 lowercase alphanumeric)"
+}
+
+variable "sku" {
+  type        = string
+  default     = "premium"
+  description = "Databricks workspace SKU"
+}
+
+variable "no_public_ip" {
+  type        = bool
+  default     = true
+  description = "Disable public IPs on cluster nodes"
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "Tags to apply to the workspace resource"
+}


### PR DESCRIPTION
Closes #13

Creates `terraform/modules/databricks-workspace/` to encapsulate the `azurerm_databricks_workspace` resource and its VNet injection `custom_parameters`. The module exposes all inputs specified in the issue (`workspace_name`, `resource_group_name`, `location`, `vnet_id`, `public_subnet_name`, `private_subnet_name`, `public_subnet_nsg_id`, `private_subnet_nsg_id`, `sku`, `no_public_ip`, `tags`) plus `storage_account_name` (required by both workspaces). Outputs are `workspace_id` and `workspace_url`.

`terraform/2-workspace/app-workspace.tf` and `auth-workspace.tf` are updated to call the module instead of declaring `azurerm_databricks_workspace` directly; the four private endpoint resources are unchanged and now reference `module.app_workspace.workspace_id` / `module.auth_workspace.workspace_id` as appropriate.

---
_Generated by [Claude Code](https://claude.ai/code/session_011zEuGNhU3XBkyFiSmTrYM3)_