### PR TITLE
Extract private endpoint pair into a reusable module

### DIFF
--- a/terraform/2-workspace/app-workspace.tf
+++ b/terraform/2-workspace/app-workspace.tf
@@ -17,21 +17,15 @@ module "app_workspace" {
 ## BACKEND PRIVATE ENDPOINT
 ###
 
-resource "azurerm_private_endpoint" "app_dpcp" {
+module "app_dpcp" {
+  source = "../modules/databricks-private-endpoint"
+
   name                = "dpcppvtendpoint"
   resource_group_name = local.rg_dataplane
   location            = var.location
   subnet_id           = data.terraform_remote_state.phase1_state.outputs.subnet_app_plsubnet_id
-
-  private_service_connection {
-    name                           = "ple-${local.prefix}-dpcp"
-    private_connection_resource_id = module.app_workspace.workspace_id
-    is_manual_connection           = false
-    subresource_names              = ["databricks_ui_api"]
-  }
-
-  private_dns_zone_group {
-    name                 = "app-private-dns-zone-dpcp"
-    private_dns_zone_ids = [data.terraform_remote_state.phase1_state.outputs.private_dns_zone_dnsdpcp_id]
-  }
+  workspace_id        = module.app_workspace.workspace_id
+  subresource_name    = "databricks_ui_api"
+  private_dns_zone_id = data.terraform_remote_state.phase1_state.outputs.private_dns_zone_dnsdpcp_id
+  tags                = local.tags
 }

--- a/terraform/2-workspace/auth-workspace.tf
+++ b/terraform/2-workspace/auth-workspace.tf
@@ -18,41 +18,29 @@ module "auth_workspace" {
 ## Frontend Private Endpoint
 ###
 
-resource "azurerm_private_endpoint" "front_pe" {
+module "front_pe" {
+  source = "../modules/databricks-private-endpoint"
+
   name                = "frontprivatendpoint"
   location            = var.location
   resource_group_name = local.rg_transit
   subnet_id           = data.terraform_remote_state.phase1_state.outputs.transit_plsubnet_id
-
-  private_service_connection {
-    name                           = "ple-${local.prefix}-uiapi"
-    private_connection_resource_id = module.app_workspace.workspace_id
-    is_manual_connection           = false
-    subresource_names              = ["databricks_ui_api"]
-  }
-
-  private_dns_zone_group {
-    name                 = "private-dns-zone-uiapi"
-    private_dns_zone_ids = [data.terraform_remote_state.phase1_state.outputs.dns_auth_front_id]
-  }
+  workspace_id        = module.app_workspace.workspace_id
+  subresource_name    = "databricks_ui_api"
+  private_dns_zone_id = data.terraform_remote_state.phase1_state.outputs.dns_auth_front_id
+  tags                = local.tags
 }
 
 
-resource "azurerm_private_endpoint" "transit_auth" {
+module "transit_auth" {
+  source = "../modules/databricks-private-endpoint"
+
   name                = "aadauthpvtendpoint-transit"
   location            = var.location
   resource_group_name = local.rg_transit
   subnet_id           = data.terraform_remote_state.phase1_state.outputs.transit_plsubnet_id
-
-  private_service_connection {
-    name                           = "ple-${local.prefix}-auth"
-    private_connection_resource_id = module.auth_workspace.workspace_id
-    is_manual_connection           = false
-    subresource_names              = ["browser_authentication"]
-  }
-
-  private_dns_zone_group {
-    name                 = "private-dns-zone-auth"
-    private_dns_zone_ids = [data.terraform_remote_state.phase1_state.outputs.dns_auth_front_id]
-  }
+  workspace_id        = module.auth_workspace.workspace_id
+  subresource_name    = "browser_authentication"
+  private_dns_zone_id = data.terraform_remote_state.phase1_state.outputs.dns_auth_front_id
+  tags                = local.tags
 }

--- a/terraform/modules/databricks-private-endpoint/main.tf
+++ b/terraform/modules/databricks-private-endpoint/main.tf
@@ -1,0 +1,19 @@
+resource "azurerm_private_endpoint" "this" {
+  name                = var.name
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  subnet_id           = var.subnet_id
+  tags                = var.tags
+
+  private_service_connection {
+    name                           = "ple-${var.name}"
+    private_connection_resource_id = var.workspace_id
+    is_manual_connection           = false
+    subresource_names              = [var.subresource_name]
+  }
+
+  private_dns_zone_group {
+    name                 = "${var.name}-dns-zone-group"
+    private_dns_zone_ids = [var.private_dns_zone_id]
+  }
+}

--- a/terraform/modules/databricks-private-endpoint/outputs.tf
+++ b/terraform/modules/databricks-private-endpoint/outputs.tf
@@ -1,0 +1,9 @@
+output "private_endpoint_id" {
+  description = "Resource ID of the private endpoint"
+  value       = azurerm_private_endpoint.this.id
+}
+
+output "private_ip_address" {
+  description = "Private IP address assigned to the private endpoint"
+  value       = azurerm_private_endpoint.this.private_service_connection[0].private_ip_address
+}

--- a/terraform/modules/databricks-private-endpoint/variables.tf
+++ b/terraform/modules/databricks-private-endpoint/variables.tf
@@ -1,0 +1,40 @@
+variable "name" {
+  type        = string
+  description = "Name of the private endpoint resource"
+}
+
+variable "resource_group_name" {
+  type        = string
+  description = "Name of the resource group to deploy the private endpoint into"
+}
+
+variable "location" {
+  type        = string
+  description = "Azure region for the private endpoint"
+}
+
+variable "subnet_id" {
+  type        = string
+  description = "Resource ID of the subnet to place the private endpoint in"
+}
+
+variable "workspace_id" {
+  type        = string
+  description = "Resource ID of the Databricks workspace to connect"
+}
+
+variable "subresource_name" {
+  type        = string
+  description = "Databricks subresource to expose (databricks_ui_api or browser_authentication)"
+}
+
+variable "private_dns_zone_id" {
+  type        = string
+  description = "Resource ID of the private DNS zone for automatic DNS registration"
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "Tags to apply to the private endpoint resource"
+}


### PR DESCRIPTION
Closes #14

Creates `terraform/modules/databricks-private-endpoint/` to encapsulate the `azurerm_private_endpoint` + DNS zone group pattern shared across all Databricks private endpoints.

**Module inputs:** `name`, `resource_group_name`, `location`, `subnet_id`, `workspace_id`, `subresource_name`, `private_dns_zone_id`, `tags`

**Module outputs:** `private_endpoint_id`, `private_ip_address`

Updates `terraform/2-workspace/` to replace the three inline `azurerm_private_endpoint` resources (`app_dpcp`, `front_pe`, `transit_auth`) with calls to this new module, eliminating the repeated private-service-connection + DNS-zone-group block pattern.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EbgZf1YcbNAwvAzgzJikqw)_