### PR TITLE
Add metastore assignment resource to stage 4

### DIFF
--- a/terraform/4-unity-catalog/metastore.tf
+++ b/terraform/4-unity-catalog/metastore.tf
@@ -1,0 +1,6 @@
+data "databricks_current_config" "this" {}
+
+resource "databricks_metastore_assignment" "this" {
+  metastore_id = var.metastore_id
+  workspace_id = data.databricks_current_config.this.workspace_id
+}

--- a/terraform/4-unity-catalog/vars.tf
+++ b/terraform/4-unity-catalog/vars.tf
@@ -1,0 +1,4 @@
+variable "metastore_id" {
+  type        = string
+  description = "ID of the existing Unity Catalog metastore (from Account Console)"
+}


### PR DESCRIPTION
Closes #16

Adds the `databricks_metastore_assignment` resource to stage 4 so an existing Unity Catalog metastore can be attached to the app workspace.

**Changes:**
- `vars.tf` — adds the `metastore_id` variable (Unity Catalog metastore UUID from the Databricks Account Console)
- `metastore.tf` (new) — declares a `databricks_current_config` data source to resolve the current workspace's numeric ID, then creates the `databricks_metastore_assignment` resource using that ID and `var.metastore_id`

---
_Generated by [Claude Code](https://claude.ai/code/session_011Y3E3Xp5ywQ6NQswftmVjq)_