### PR TITLE
Add catalog, schema, and storage credential to stage 4

### DIFF
--- a/terraform/4-unity-catalog/catalog.tf
+++ b/terraform/4-unity-catalog/catalog.tf
@@ -1,0 +1,19 @@
+resource "databricks_storage_credential" "main" {
+  name = "${var.catalog_name}-credential"
+  azure_managed_identity {
+    access_connector_id = var.managed_identity_id
+  }
+  depends_on = [databricks_metastore_assignment.this]
+}
+
+resource "databricks_catalog" "main" {
+  name    = var.catalog_name
+  comment = "Root catalog — storage access via ${databricks_storage_credential.main.name}"
+
+  depends_on = [databricks_storage_credential.main]
+}
+
+resource "databricks_schema" "default" {
+  catalog_name = databricks_catalog.main.name
+  name         = "default"
+}

--- a/terraform/4-unity-catalog/vars.tf
+++ b/terraform/4-unity-catalog/vars.tf
@@ -2,3 +2,14 @@ variable "metastore_id" {
   type        = string
   description = "ID of the existing Unity Catalog metastore (from Account Console)"
 }
+
+variable "catalog_name" {
+  type        = string
+  default     = "main"
+  description = "Name of the Unity Catalog catalog to create"
+}
+
+variable "managed_identity_id" {
+  type        = string
+  description = "Resource ID of the Azure Access Connector (managed identity) for the storage credential"
+}


### PR DESCRIPTION
Closes #17

Adds Unity Catalog resources to `terraform/4-unity-catalog/` via a new `catalog.tf` file:

- `databricks_storage_credential` — backed by a user-assigned managed identity (Azure Access Connector), created after the metastore assignment is in place
- `databricks_catalog` — named by `var.catalog_name` (default `"main"`), depends on the storage credential
- `databricks_schema` — a `default` schema within the catalog

Two variables added to `vars.tf`:
- `catalog_name` (default `"main"`) — name of the catalog to create
- `managed_identity_id` — resource ID of the Azure Access Connector used for the storage credential

---
_Generated by [Claude Code](https://claude.ai/code/session_01G6qBnbMygAFwwoijPhjFPu)_