### PR TITLE
Add Azure Key Vault-backed secret scope to stage 3

### DIFF
--- a/terraform/3-databricks/databricks.md
+++ b/terraform/3-databricks/databricks.md
@@ -24,3 +24,18 @@ This is the first step that includes the Databricks Provider. The Azure is kept 
 Before running this stage you will need to do the following:
 - Link your workspace to an established Unity Catalog metastore for your environment
 - Grant permissions to your account within the workspace
+
+## Secret Scope (Azure Key Vault-backed)
+
+`secret-scope.tf` provisions a Databricks secret scope backed by an Azure Key Vault, enabling notebooks and jobs to read secrets from the vault without embedding credentials in code.
+
+The scope is created via Databricks' Azure Key Vault integration (`keyvault_metadata`), which means the vault's secrets are accessed directly — they are not copied into Databricks.
+
+**Variables required:**
+
+| Variable | Description |
+|---|---|
+| `key_vault_id` | Full Azure resource ID of the Key Vault (e.g. `/subscriptions/.../resourceGroups/.../providers/Microsoft.KeyVault/vaults/my-vault`) |
+| `key_vault_uri` | Vault URI (e.g. `https://my-vault.vault.azure.net/`) |
+
+**Prerequisites:** The Key Vault must pre-exist, and the workspace managed identity must be granted the **Key Vault Secrets User** role on the vault before Terraform can create the scope.

--- a/terraform/3-databricks/secret-scope.tf
+++ b/terraform/3-databricks/secret-scope.tf
@@ -1,0 +1,8 @@
+resource "databricks_secret_scope" "key_vault" {
+  name = "${var.naming_prefix}-kv-scope"
+
+  keyvault_metadata {
+    resource_id = var.key_vault_id
+    dns_name    = var.key_vault_uri
+  }
+}

--- a/terraform/3-databricks/vars.tf
+++ b/terraform/3-databricks/vars.tf
@@ -22,3 +22,13 @@ variable "environment" {
   type    = string
   default = "Demo"
 }
+
+variable "key_vault_id" {
+  type        = string
+  description = "Resource ID of the Azure Key Vault to back the secret scope"
+}
+
+variable "key_vault_uri" {
+  type        = string
+  description = "Vault URI of the Azure Key Vault"
+}


### PR DESCRIPTION
Closes #19

Adds a Databricks secret scope backed by Azure Key Vault to `terraform/3-databricks/`:

- New `secret-scope.tf` with a `databricks_secret_scope` resource using `keyvault_metadata` — secrets are read directly from the vault, not copied into Databricks
- Two new variables in `vars.tf`: `key_vault_id` (the full Azure resource ID) and `key_vault_uri` (the vault DNS name)
- Updated `databricks.md` with a section describing the secret scope, required variables, and the prerequisite that the workspace managed identity must hold the **Key Vault Secrets User** role on the vault

https://claude.ai/code/session_01WeatPjQwGjHuK4PhHPHiJ9

---
_Generated by [Claude Code](https://claude.ai/code/session_01WeatPjQwGjHuK4PhHPHiJ9)_