### PR TITLE
Scaffold first DABS example — batch ETL job

### DIFF
--- a/dabs/batch-etl/README.md
+++ b/dabs/batch-etl/README.md
@@ -1,0 +1,58 @@
+# Batch ETL — Databricks Asset Bundle
+
+A minimal [Databricks Asset Bundle](https://docs.databricks.com/en/dev-tools/bundles/index.html) that deploys a batch ETL job running a PySpark notebook on the app workspace.
+
+## Prerequisites
+
+| Requirement | Notes |
+|---|---|
+| [Databricks CLI v0.220+](https://docs.databricks.com/en/dev-tools/cli/install.html) | `brew install databricks` or download from GitHub releases |
+| Authenticated session | Run `databricks auth login --host <workspace-url>` once per machine |
+| App workspace deployed | Stage 2 Terraform must be applied and the workspace URL must be known |
+| Stage 3 cluster policy | Stage 3 Terraform must be applied to create the cluster policies |
+
+## Variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `workspace_url` | Yes | Full HTTPS URL of the app workspace (e.g. `https://adb-123.azuredatabricks.net`) |
+| `cluster_policy_id` | No | Policy ID from stage 3 outputs (`single_node_policy_id` or `standard_policy_id`). Leave empty to use no policy. |
+
+Look up the policy ID from the Terraform output:
+
+```bash
+cd terraform/3-databricks
+terraform output single_node_policy_id
+```
+
+## Deploy
+
+```bash
+cd dabs/batch-etl
+
+# Validate the bundle
+databricks bundle validate --target dev \
+  -v workspace_url=https://<workspace>.azuredatabricks.net
+
+# Deploy (uploads the notebook and creates the job)
+databricks bundle deploy --target dev \
+  -v workspace_url=https://<workspace>.azuredatabricks.net \
+  -v cluster_policy_id=<policy-id>
+
+# Run the job immediately
+databricks bundle run batch_etl_job --target dev \
+  -v workspace_url=https://<workspace>.azuredatabricks.net
+```
+
+## Tear down
+
+```bash
+databricks bundle destroy --target dev \
+  -v workspace_url=https://<workspace>.azuredatabricks.net
+```
+
+## Customising the notebook
+
+Edit `src/etl_notebook.py`. The file uses standard Python — replace the placeholder
+`createDataFrame` call with real data sources (ADLS Gen2 mounts, Unity Catalog volumes,
+or external tables) and write the result to a Delta table with `saveAsTable`.

--- a/dabs/batch-etl/databricks.yml
+++ b/dabs/batch-etl/databricks.yml
@@ -1,0 +1,36 @@
+bundle:
+  name: batch-etl
+
+variables:
+  workspace_url:
+    description: "URL of the app Databricks workspace (e.g. https://<id>.azuredatabricks.net)"
+  cluster_policy_id:
+    description: "ID of the cluster policy from stage 3 (single_node_policy_id or standard_policy_id)"
+    default: ""
+
+targets:
+  dev:
+    workspace:
+      host: ${var.workspace_url}
+
+resources:
+  jobs:
+    batch_etl_job:
+      name: batch-etl-job
+
+      tasks:
+        - task_key: etl_notebook
+          notebook_task:
+            notebook_path: ./src/etl_notebook.py
+            source: WORKSPACE
+
+          new_cluster:
+            spark_version: "auto:latest-lts"
+            num_workers: 0
+            spark_conf:
+              spark.databricks.cluster.profile: singleNode
+              spark.master: "local[*]"
+            policy_id: ${var.cluster_policy_id}
+            azure_attributes:
+              availability: SPOT_AZURE
+            autotermination_minutes: 30

--- a/dabs/batch-etl/src/etl_notebook.py
+++ b/dabs/batch-etl/src/etl_notebook.py
@@ -1,0 +1,36 @@
+# Databricks notebook source
+# COMMAND ----------
+
+# Placeholder batch ETL notebook
+# Replace the sections below with your actual data sources and transformations.
+
+from pyspark.sql import SparkSession
+from pyspark.sql import functions as F
+
+spark = SparkSession.builder.getOrCreate()
+
+# COMMAND ----------
+
+# --- Extract ---
+# Read raw data from a source (e.g. ADLS Gen2 mount, Unity Catalog volume, or Delta table).
+# Example:
+#   df_raw = spark.read.format("parquet").load("/mnt/raw/events/")
+
+df_raw = spark.createDataFrame(
+    [("alice", 1), ("bob", 2), ("alice", 3)],
+    schema=["name", "value"],
+)
+
+# COMMAND ----------
+
+# --- Transform ---
+df_agg = df_raw.groupBy("name").agg(F.sum("value").alias("total_value"))
+
+# COMMAND ----------
+
+# --- Load ---
+# Write the result to a Delta table or Unity Catalog.
+# Example:
+#   df_agg.write.format("delta").mode("overwrite").saveAsTable("main.default.batch_etl_output")
+
+display(df_agg)


### PR DESCRIPTION
Closes #20

Adds a minimal Databricks Asset Bundle for a batch ETL job under `dabs/batch-etl/`:

- `databricks.yml` — defines a `dev` target (workspace URL as a variable), a job with a single notebook task, and an auto-terminating single-node cluster that references the cluster policy from stage 3 via a `cluster_policy_id` variable.
- `src/etl_notebook.py` — placeholder PySpark notebook with extract / transform / load skeleton using standard `%python` cell separation comments.
- `README.md` — covers prerequisites (Databricks CLI, `databricks auth login`), variable descriptions, and `bundle validate / deploy / run / destroy` commands.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YTvojJjc5WBgfs5wkZE3yG)_