### PR TITLE
Create streaming ETL DABS example with Delta Live Tables

### DIFF
--- a/dabs/streaming-etl/README.md
+++ b/dabs/streaming-etl/README.md
@@ -1,0 +1,93 @@
+# Streaming ETL — Databricks Asset Bundle (Delta Live Tables)
+
+A [Databricks Asset Bundle](https://docs.databricks.com/en/dev-tools/bundles/index.html) that deploys a [Delta Live Tables](https://docs.databricks.com/en/delta-live-tables/index.html) pipeline implementing a three-layer streaming medallion architecture (Bronze → Silver → Gold).
+
+## DLT concepts
+
+| Concept | Description |
+|---|---|
+| **Pipeline** | The DLT unit of deployment. Groups one or more notebooks/Python files that define tables and views. |
+| **`@dlt.view`** | Defines a virtual, non-materialised dataset — useful for lightweight sources or intermediate steps that do not need to be stored. |
+| **`@dlt.table`** | Defines a materialised Delta table managed by DLT. DLT handles schema evolution, checkpointing, and optimisation automatically. |
+| **`@dlt.expect_or_drop`** | A data quality constraint. Rows that violate it are silently dropped before reaching the target table. |
+| **Auto Loader (`cloudFiles`)** | Incrementally ingests files from cloud storage (ADLS Gen2, S3, GCS) using checkpointing so each file is processed exactly once. |
+| **Triggered mode** | The pipeline runs once and shuts down. Good for scheduled batch-like pipelines that should not incur continuous compute cost. |
+| **Continuous mode** | The pipeline keeps a cluster alive and processes data with low latency as it arrives. |
+
+## Prerequisites
+
+| Requirement | Notes |
+|---|---|
+| [Databricks CLI v0.220+](https://docs.databricks.com/en/dev-tools/cli/install.html) | `brew install databricks` or download from GitHub releases |
+| Authenticated session | Run `databricks auth login --host <workspace-url>` once per machine |
+| App workspace deployed | Stage 2 Terraform must be applied and the workspace URL must be known |
+| Unity Catalog attached | Stage 3 manual step (metastore attachment) and stage 4 Terraform must be complete |
+
+## Variables
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `workspace_url` | Yes | — | Full HTTPS URL of the app workspace (e.g. `https://adb-123.azuredatabricks.net`) |
+| `catalog_name` | No | `main` | Unity Catalog catalog created by stage 4 Terraform |
+| `schema_name` | No | `default` | Schema inside the catalog where DLT writes its managed tables |
+| `continuous` | No | `false` | Set to `true` for low-latency continuous mode |
+
+Look up the catalog name from the stage 4 Terraform output:
+
+```bash
+cd terraform/4-unity-catalog
+terraform output catalog_name
+```
+
+## Deploy
+
+```bash
+cd dabs/streaming-etl
+
+# Validate the bundle (no workspace connection required)
+databricks bundle validate --target dev \
+  -v workspace_url=https://<workspace>.azuredatabricks.net
+
+# Deploy (creates or updates the DLT pipeline in the workspace)
+databricks bundle deploy --target dev \
+  -v workspace_url=https://<workspace>.azuredatabricks.net \
+  -v catalog_name=main \
+  -v schema_name=default
+```
+
+## Trigger a pipeline update
+
+After deploying, start a pipeline run (triggered mode):
+
+```bash
+databricks bundle run streaming_etl_pipeline --target dev \
+  -v workspace_url=https://<workspace>.azuredatabricks.net
+```
+
+To switch to **continuous mode** (cluster stays alive):
+
+```bash
+databricks bundle deploy --target dev \
+  -v workspace_url=https://<workspace>.azuredatabricks.net \
+  -v continuous=true
+
+# The pipeline starts automatically once redeployed in continuous mode.
+# To stop it, redeploy with continuous=false or destroy the pipeline.
+```
+
+## Tear down
+
+```bash
+databricks bundle destroy --target dev \
+  -v workspace_url=https://<workspace>.azuredatabricks.net
+```
+
+## Customising the pipeline
+
+Edit `src/dlt_pipeline.py`:
+
+- **Bronze** — replace the `cloudFiles` path in `raw_events` with your actual ADLS Gen2 path or Unity Catalog volume (e.g. `/Volumes/main/default/landing/`).
+- **Silver** — adjust the `expect_or_drop` constraints to match your data quality rules.
+- **Gold** — add more aggregations or additional `@dlt.table` definitions for different consumer views.
+
+All three layers are automatically orchestrated by DLT — there is no explicit dependency wiring needed.

--- a/dabs/streaming-etl/databricks.yml
+++ b/dabs/streaming-etl/databricks.yml
@@ -1,0 +1,37 @@
+bundle:
+  name: streaming-etl
+
+variables:
+  workspace_url:
+    description: "URL of the app Databricks workspace (e.g. https://<id>.azuredatabricks.net)"
+  catalog_name:
+    description: "Unity Catalog catalog created by stage 4 Terraform"
+    default: "main"
+  schema_name:
+    description: "Schema (database) inside the catalog where DLT writes tables"
+    default: "default"
+  continuous:
+    description: "true = keep a cluster running permanently; false (default) = triggered mode, runs on demand"
+    default: "false"
+
+targets:
+  dev:
+    workspace:
+      host: ${var.workspace_url}
+
+resources:
+  pipelines:
+    streaming_etl_pipeline:
+      name: streaming-etl-pipeline
+
+      catalog: ${var.catalog_name}
+      target: ${var.schema_name}
+
+      continuous: ${var.continuous}
+
+      libraries:
+        - notebook:
+            path: ./src/dlt_pipeline.py
+
+      configuration:
+        pipelines.enableTrackHistory: "true"

--- a/dabs/streaming-etl/src/dlt_pipeline.py
+++ b/dabs/streaming-etl/src/dlt_pipeline.py
@@ -1,0 +1,76 @@
+# Databricks notebook source
+# COMMAND ----------
+
+# Delta Live Tables streaming pipeline
+# Implements a three-layer medallion pattern: Bronze → Silver → Gold.
+# DLT manages checkpointing, schema evolution, and data quality automatically.
+
+import dlt
+from pyspark.sql import functions as F
+from pyspark.sql.types import StructType, StructField, StringType, LongType, DoubleType
+
+# COMMAND ----------
+
+# --- Bronze layer: ingest raw events via Auto Loader ---
+# @dlt.view keeps the result in memory; it is not materialised as a Delta table.
+# Use it for lightweight transformations or sources you want to reference by name.
+
+@dlt.view(
+    comment="Raw events streamed from ADLS Gen2 via Auto Loader (cloudFiles).",
+)
+def raw_events():
+    # Replace the path below with your actual ADLS Gen2 or Unity Catalog volume path.
+    # Auto Loader (cloudFiles) handles schema inference and file-tracking automatically.
+    return (
+        spark.readStream
+            .format("cloudFiles")
+            .option("cloudFiles.format", "json")
+            .option("cloudFiles.schemaLocation", "/tmp/streaming_etl_schema")
+            .load("/databricks-datasets/structured-streaming/events/")
+    )
+
+# COMMAND ----------
+
+# --- Silver layer: cleaned and deduplicated events ---
+# @dlt.table materialises the result as a managed Delta table in the target schema.
+# `expect` / `expect_or_drop` clauses enforce data quality as declarative constraints.
+
+@dlt.table(
+    comment="Deduplicated events with parsed timestamp. Rows failing quality checks are dropped.",
+    table_properties={"quality": "silver", "delta.autoOptimize.optimizeWrite": "true"},
+)
+@dlt.expect_or_drop("valid_action", "action IS NOT NULL")
+@dlt.expect_or_drop("valid_time",   "timestamp IS NOT NULL")
+def cleaned_events():
+    return (
+        dlt.read_stream("raw_events")
+            .dropDuplicates(["id"])
+            .withColumn("event_ts", F.to_timestamp(F.col("timestamp").cast("double")))
+            .select("id", "action", "event_ts")
+    )
+
+# COMMAND ----------
+
+# --- Gold layer: aggregated metrics ---
+# Gold tables are typically read by BI tools or downstream jobs.
+# Using dlt.read() (non-streaming) to consume the Silver table as a batch.
+
+@dlt.table(
+    comment="Hourly event counts per action type, derived from the Silver layer.",
+    table_properties={"quality": "gold"},
+)
+def hourly_event_counts():
+    return (
+        dlt.read("cleaned_events")
+            .groupBy(
+                F.window("event_ts", "1 hour").alias("hour_window"),
+                "action",
+            )
+            .agg(F.count("*").alias("event_count"))
+            .select(
+                F.col("hour_window.start").alias("window_start"),
+                F.col("hour_window.end").alias("window_end"),
+                "action",
+                "event_count",
+            )
+    )


### PR DESCRIPTION
Closes #21

Adds `dabs/streaming-etl/` with three files consistent with the existing `dabs/batch-etl/` scaffold:

- **`databricks.yml`** — defines a `pipelines` DLT resource with four variables: `workspace_url`, `catalog_name` (default `main`), `schema_name` (default `default`), and `continuous` (default `false` for triggered mode). Storage location targets the Unity Catalog catalog from stage 4.
- **`src/dlt_pipeline.py`** — a three-layer medallion pipeline using `@dlt.view` (Bronze Auto Loader ingest), `@dlt.table` with `@dlt.expect_or_drop` constraints (Silver deduplication), and a batch-read Gold aggregation table.
- **`README.md`** — explains DLT concepts (view vs table, expect constraints, Auto Loader, triggered vs continuous mode) and documents deploy, run, and destroy commands.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GBLLbEmuTKJXfgVLm9iZrh)_